### PR TITLE
fix: compatibility with Jellyfin 10.11.5+ (tested on 10.11.9)

### DIFF
--- a/src/Jellyfin.Plugin.JellyBridge/JellyBridge.csproj
+++ b/src/Jellyfin.Plugin.JellyBridge/JellyBridge.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <JellyfinVersion>10.10.7</JellyfinVersion>
+    <JellyfinVersion>10.11.9</JellyfinVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Jellyfin.Plugin.JellyBridge</RootNamespace>
-    <AssemblyVersion>2.4.0.10</AssemblyVersion>
-    <FileVersion>2.4.0.10</FileVersion>
+    <AssemblyVersion>2.4.0.11</AssemblyVersion>
+    <FileVersion>2.4.0.11</FileVersion>
   </PropertyGroup>
 
   <!-- Normalize JellyfinVersion to specific NuGet versions -->
   <PropertyGroup>
     <NormalizedJellyfinVersion Condition="$(JellyfinVersion.StartsWith('10.10'))">10.10.7</NormalizedJellyfinVersion>
-    <NormalizedJellyfinVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">10.11.0</NormalizedJellyfinVersion>
+    <NormalizedJellyfinVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</NormalizedJellyfinVersion>
     <NormalizedJellyfinVersion Condition="'$(NormalizedJellyfinVersion)' == ''">$(JellyfinVersion)</NormalizedJellyfinVersion>
   </PropertyGroup>
 
@@ -53,11 +53,11 @@
 
   <!-- Microsoft.Extensions packages for .NET 9.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
   </ItemGroup>
 
 

--- a/src/Jellyfin.Plugin.JellyBridge/JellyfinModels/JellyfinIUserManager.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/JellyfinModels/JellyfinIUserManager.cs
@@ -17,7 +17,7 @@ public class JellyfinIUserManager : WrapperBase<IUserManager>
     /// </summary>
     public IEnumerable<JellyfinUser> GetAllUsers()
     {
-        return Inner.Users.Select(user => new JellyfinUser((dynamic)user));
+        return Inner.GetUsers().Select(user => new JellyfinUser((dynamic)user));
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.JellyBridge/Services/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/Services/PluginServiceRegistrator.cs
@@ -22,36 +22,39 @@ namespace Jellyfin.Plugin.JellyBridge.Services
             serviceCollection.AddLogging();
             
             // Register HTTP client for Jellyseerr API
+            // NOTE: AddHttpClient registers ApiService as transient with a properly
+            // lifecycle-managed HttpClient from IHttpClientFactory. Do NOT add a
+            // second AddScoped<ApiService>() as it would override this and cause
+            // ObjectDisposedException in Jellyfin 10.11.5+.
             serviceCollection.AddHttpClient<ApiService>();
-            
-            // Register Jellyfin wrapper classes (only those with version differences)
-            serviceCollection.AddScoped<JellyfinILibraryManager>(provider => 
+
+            // Register Jellyfin wrapper classes as transient to avoid scope disposal issues
+            serviceCollection.AddTransient<JellyfinILibraryManager>(provider =>
                 new JellyfinILibraryManager(provider.GetRequiredService<MediaBrowser.Controller.Library.ILibraryManager>()));
-            serviceCollection.AddScoped<JellyfinIUserDataManager>(provider => 
+            serviceCollection.AddTransient<JellyfinIUserDataManager>(provider =>
                 new JellyfinIUserDataManager(provider.GetRequiredService<MediaBrowser.Controller.Library.IUserDataManager>()));
-            serviceCollection.AddScoped<JellyfinIUserManager>(provider =>
+            serviceCollection.AddTransient<JellyfinIUserManager>(provider =>
                 new JellyfinIUserManager(provider.GetRequiredService<MediaBrowser.Controller.Library.IUserManager>()));
-            serviceCollection.AddScoped<JellyfinIProviderManager>(provider =>
+            serviceCollection.AddTransient<JellyfinIProviderManager>(provider =>
                 new JellyfinIProviderManager(provider.GetRequiredService<MediaBrowser.Controller.Providers.IProviderManager>()));
-            
-            // Register the base services
-            serviceCollection.AddScoped<ApiService>();
-            serviceCollection.AddScoped<SyncService>();
-            serviceCollection.AddScoped<MetadataService>();
-            serviceCollection.AddScoped<SortService>();
-            serviceCollection.AddScoped<CleanupService>();
-            
+
+            // Register the base services as transient to avoid scope disposal issues in 10.11.5+
+            serviceCollection.AddTransient<SyncService>();
+            serviceCollection.AddTransient<MetadataService>();
+            serviceCollection.AddTransient<SortService>();
+            serviceCollection.AddTransient<CleanupService>();
+
             // Register the bridge service
-            serviceCollection.AddScoped<BridgeService>();
-            
+            serviceCollection.AddTransient<BridgeService>();
+
             // Register the discover service
-            serviceCollection.AddScoped<DiscoverService>();
-            
+            serviceCollection.AddTransient<DiscoverService>();
+
             // Register the favorite service
-            serviceCollection.AddScoped<FavoriteService>();
-            
+            serviceCollection.AddTransient<FavoriteService>();
+
             // Register the library service
-            serviceCollection.AddScoped<LibraryService>();
+            serviceCollection.AddTransient<LibraryService>();
             
             // Register placeholder video generator as transient to avoid early initialization
             serviceCollection.AddTransient<PlaceholderVideoGenerator>();

--- a/src/Jellyfin.Plugin.JellyBridge/Tasks/SortTask.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/Tasks/SortTask.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Jellyfin.Plugin.JellyBridge.Configuration;
 using Jellyfin.Plugin.JellyBridge.Services;
 using Jellyfin.Plugin.JellyBridge.BridgeModels;
@@ -15,17 +16,14 @@ namespace Jellyfin.Plugin.JellyBridge.Tasks;
 public class SortTask : IScheduledTask
 {
     private readonly DebugLogger<SortTask> _logger;
-    private readonly SortService _sortService;
-    private readonly LibraryService _libraryService;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     public SortTask(
         ILogger<SortTask> logger,
-        SortService sortService,
-        LibraryService libraryService)
+        IServiceScopeFactory scopeFactory)
     {
         _logger = new DebugLogger<SortTask>(logger);
-        _sortService = sortService;
-        _libraryService = libraryService;
+        _scopeFactory = scopeFactory;
         _logger.LogInformation("SortTask constructor called - task initialized");
     }
 
@@ -39,21 +37,25 @@ public class SortTask : IScheduledTask
         try
         {
             _logger.LogInformation("Starting sort task");
-            
+
+            using var scope = _scopeFactory.CreateScope();
+            var sortService = scope.ServiceProvider.GetRequiredService<SortService>();
+            var libraryService = scope.ServiceProvider.GetRequiredService<LibraryService>();
+
             // Use Jellyfin-style locking that pauses instead of canceling
             await Plugin.ExecuteWithLockAsync<object?>(async () =>
             {
                 progress.Report(10);
-                
+
                 // Sort discover library by updating play counts for all users
-                var sortResult = await _sortService.SortJellyBridge();
-                
+                var sortResult = await sortService.SortJellyBridge();
+
                 progress.Report(50);
-                
+
                 // Refresh library to reload user data (play counts) if refresh is needed
                 if (sortResult.Refresh != null)
                 {
-                    await _libraryService.RefreshBridgeLibrary(createMode: false, removeMode: false);
+                    await libraryService.RefreshBridgeLibrary(createMode: false, removeMode: false);
                 }
                 
                 progress.Report(100);

--- a/src/Jellyfin.Plugin.JellyBridge/Tasks/StartupTask.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/Tasks/StartupTask.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Jellyfin.Plugin.JellyBridge.Configuration;
 using Jellyfin.Plugin.JellyBridge.Services;
 using MediaBrowser.Model.Tasks;
@@ -13,16 +14,16 @@ namespace Jellyfin.Plugin.JellyBridge.Tasks;
 public class StartupTask : IScheduledTask
 {
     private readonly DebugLogger<StartupTask> _logger;
-    private readonly SyncService _syncService;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ITaskManager _taskManager;
 
     public StartupTask(
         ILogger<StartupTask> logger,
-        SyncService syncService,
+        IServiceScopeFactory scopeFactory,
         ITaskManager taskManager)
     {
         _logger = new DebugLogger<StartupTask>(logger);
-        _syncService = syncService;
+        _scopeFactory = scopeFactory;
         _taskManager = taskManager;
     }
 
@@ -36,7 +37,10 @@ public class StartupTask : IScheduledTask
         try
         {
             _logger.LogInformation("Starting startup task execution");
-            
+
+            using var scope = _scopeFactory.CreateScope();
+            var syncService = scope.ServiceProvider.GetRequiredService<SyncService>();
+
             var autoSyncOnStartup = Plugin.GetConfigOrDefault<bool>(nameof(PluginConfiguration.EnableStartupSync));
             var startupDelaySeconds = Plugin.GetConfigOrDefault<int>(nameof(PluginConfiguration.StartupDelaySeconds));
             var isSyncEnabled = Plugin.GetConfigOrDefault<bool>(nameof(PluginConfiguration.IsEnabled));

--- a/src/Jellyfin.Plugin.JellyBridge/Tasks/SyncTask.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/Tasks/SyncTask.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Jellyfin.Plugin.JellyBridge.Configuration;
 using Jellyfin.Plugin.JellyBridge.Controllers;
 using Jellyfin.Plugin.JellyBridge.Services;
@@ -16,24 +17,18 @@ namespace Jellyfin.Plugin.JellyBridge.Tasks;
 public class SyncTask : IScheduledTask
 {
     private readonly DebugLogger<SyncTask> _logger;
-    private readonly SyncService _syncService;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ITaskManager _taskManager;
-    private readonly PlaceholderVideoGenerator _placeholderVideoGenerator;
-    private readonly CleanupService _cleanupService;
 
 
     public SyncTask(
         ILogger<SyncTask> logger,
-        SyncService syncService,
-        ITaskManager taskManager,
-        PlaceholderVideoGenerator placeholderVideoGenerator,
-        CleanupService cleanupService)
+        IServiceScopeFactory scopeFactory,
+        ITaskManager taskManager)
     {
         _logger = new DebugLogger<SyncTask>(logger);
-        _syncService = syncService;
+        _scopeFactory = scopeFactory;
         _taskManager = taskManager;
-        _placeholderVideoGenerator = placeholderVideoGenerator;
-        _cleanupService = cleanupService;
         _logger.LogInformation("SyncTask constructor called - task initialized");
     }
 
@@ -47,23 +42,29 @@ public class SyncTask : IScheduledTask
         try
         {
             _logger.LogInformation("Starting interval sync task");
-            
+
+            // Create a fresh DI scope for this execution so services are not
+            // affected by scope disposal in Jellyfin 10.11.5+ (ObjectDisposedException fix)
+            using var scope = _scopeFactory.CreateScope();
+            var syncService = scope.ServiceProvider.GetRequiredService<SyncService>();
+            var cleanupService = scope.ServiceProvider.GetRequiredService<CleanupService>();
+
             // Use Jellyfin-style locking that pauses instead of canceling
             await Plugin.ExecuteWithLockAsync<(CleanupResult?, SyncJellyfinResult?, SyncJellyseerrResult?)>(async () =>
             {
                 CleanupResult? cleanupResult = null;
                 SyncJellyseerrResult? syncFromResult = null;
                 SyncJellyfinResult? syncToResult = null;
-                
+
                 // Initial report to indicate the task has started
                 progress.Report(10);
 
                 // Step 1: Sync discover from Jellyseerr
                 _logger.LogDebug("Step 1: Syncing discover from Jellyseerr...");
-                
+
                 try
                 {
-                    syncFromResult = await _syncService.SyncFromJellyseerr();
+                    syncFromResult = await syncService.SyncFromJellyseerr();
                 }
                 catch (Exception ex)
                 {
@@ -77,13 +78,13 @@ public class SyncTask : IScheduledTask
                 } finally {
                     progress.Report(40);
                 }
-                
+
                 // Step 2: Sync favorites to Jellyseerr
                 _logger.LogDebug("Step 2: Syncing favorites to Jellyseerr...");
-                
+
                 try
                 {
-                    syncToResult = await _syncService.SyncToJellyseerr();
+                    syncToResult = await syncService.SyncToJellyseerr();
                 }
                 catch (Exception ex)
                 {
@@ -95,40 +96,34 @@ public class SyncTask : IScheduledTask
                         Details = $"Exception type: {ex.GetType().Name}\nStack trace: {ex.StackTrace}"
                     };
                 } finally {
-                    progress.Report(90);
+                    progress.Report(70);
                 }
-                
+
                 // Step 3: Cleanup metadata after sync operations
                 _logger.LogDebug("Step 3: Cleaning up metadata...");
-                
+
                 try
                 {
-                    cleanupResult = await _cleanupService.CleanupMetadataAsync();
+                    cleanupResult = await cleanupService.CleanupMetadataAsync();
                     _logger.LogDebug("Step 3: Cleanup completed successfully");
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error during metadata cleanup");
-                    // Continue with sync operations even if cleanup fails
                 }
                 finally
                 {
                     progress.Report(90);
                 }
 
-                // Show results of sync operations in logs for debugging
+                // Show results and apply refresh
                 try {
                     if (syncToResult != null)
-                    {
                         _logger.LogInformation("Sync to Jellyseerr result: {Result}", syncToResult.ToString());
-                    }
                     if (syncFromResult != null)
-                    {
                         _logger.LogInformation("Sync from Jellyseerr result: {Result}", syncFromResult.ToString());
-                    }
 
-                    // Apply refresh operations after both syncs are complete
-                    await _syncService.ApplyRefreshAsync(syncToResult, syncFromResult, cleanupResult);
+                    await syncService.ApplyRefreshAsync(syncToResult, syncFromResult, cleanupResult);
                 } catch (Exception ex) {
                     _logger.LogError(ex, "Error applying refresh operations");
                 } finally {


### PR DESCRIPTION
## Problem

JellyBridge fails silently on Jellyfin 10.11.5+ (tested on 10.11.9). The sync to Jellyseerr never runs and user requests are never created. Three separate breaking changes were introduced between 10.11.4 and 10.11.9.

## Root causes & fixes

### 1. `IUserManager.Users` property removed in 10.11.5+

**File:** `JellyfinModels/JellyfinIUserManager.cs`

Jellyfin removed the `Users` property from `IUserManager` and replaced it with the `GetUsers()` method. This caused a `MissingMethodException` at runtime, which was caught and reported as "Using incompatible Jellyfin version. Skipping sync to Jellyseerr."

```csharp
// Before
return Inner.Users.Select(user => new JellyfinUser((dynamic)user));

// After
return Inner.GetUsers().Select(user => new JellyfinUser((dynamic)user));
```

### 2. Duplicate `ApiService` registration causing `ObjectDisposedException`

**File:** `Services/PluginServiceRegistrator.cs`

`AddHttpClient<ApiService>()` was followed by `AddScoped<ApiService>()`. In .NET DI the last registration wins, so the typed HttpClient factory was bypassed. The resulting `HttpClient` had an unmanaged lifecycle and was disposed mid-request.

Fix: removed the duplicate `AddScoped<ApiService>()`. Also changed all other plugin services from `AddScoped` to `AddTransient` to avoid related scope issues.

### 3. Scheduled tasks holding expired scoped service references

**Files:** `Tasks/SyncTask.cs`, `Tasks/SortTask.cs`, `Tasks/StartupTask.cs`

In Jellyfin 10.11.5+, `IScheduledTask` instances appear to be resolved differently, causing the DI scope that owns the injected services to be disposed before `ExecuteAsync` completes. This triggered `ObjectDisposedException: Cannot access a disposed object` from `MemoryCache` during the Jellyseerr API call.

Fix: replaced constructor-injected services with `IServiceScopeFactory`. Each `ExecuteAsync` creates its own `using var scope = _scopeFactory.CreateScope()` and resolves services from it.

## Build changes

- `JellyfinVersion` bumped to `10.11.9`
- `NormalizedJellyfinVersion` now passes the full version for 10.11.x (not pinned to `10.11.0`)
- `Microsoft.Extensions.*` packages bumped to `9.0.11` (required by Jellyfin 10.11.9 NuGet deps)

## Tested on

- Jellyfin **10.11.9** (author)
- Jellyfin **10.11.10** (confirmed by @PyRowMan)
- Jellyseerr **2.7.3**
- Both `✅ Sync from Jellyseerr` and `✅ Sync to Jellyseerr` complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)