### PR TITLE
fix: replace IUserManager.Users with GetUsers() for Jellyfin 10.11.10 compatibility

### DIFF
--- a/src/Jellyfin.Plugin.JellyBridge/JellyfinModels/JellyfinIUserManager.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/JellyfinModels/JellyfinIUserManager.cs
@@ -17,7 +17,8 @@ public class JellyfinIUserManager : WrapperBase<IUserManager>
     /// </summary>
     public IEnumerable<JellyfinUser> GetAllUsers()
     {
-        return Inner.Users.Select(user => new JellyfinUser((dynamic)user));
+        var users = Inner.GetUsers();
+        return users.Select(user => new JellyfinUser((dynamic)user));
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

JellyBridge crashes with a `MissingMethodException` on Jellyfin 10.11.10+:

```
Method not found: 'System.Collections.Generic.IEnumerable`1<MediaBrowser.Controller.Library.User> IUserManager.get_Users()'.
```

The `IUserManager.Users` property was removed in Jellyfin 10.11.10 and replaced by the `GetUsers()` method.

## Fix

Replace `Inner.Users.Select(...)` with `Inner.GetUsers().Select(...)` in `JellyfinIUserManager.GetAllUsers()`.

The `GetUsers()` method has been available since Jellyfin 10.9.x, so this change is backward-compatible.

## Testing

Verified on Jellyfin 10.11.10:
- `GetAllUsers()` no longer throws `MissingMethodException`
- `SyncToJellyseerr` completes successfully with `success: true`
- Favorites are correctly retrieved, filtered, and requests are created in Jellyseerr