### PR TITLE
fix: correct plexId and plexToken type from string to int

### DIFF
--- a/src/Jellyfin.Plugin.JellyBridge/JellyseerrModel/Common/user.cs
+++ b/src/Jellyfin.Plugin.JellyBridge/JellyseerrModel/Common/user.cs
@@ -52,7 +52,7 @@ public class User
     public UserType UserType { get; set; } = new();
 
     [JsonPropertyName("plexId")]
-    public string? PlexId { get; set; } = null!;
+    public int? PlexId { get; set; }
 
     [JsonPropertyName("jellyfinUserId")]
     public string? JellyfinUserId { get; set; } = null!;


### PR DESCRIPTION
System.Text.Json refuses to deserialize a JSON number into `string?`, which causes `SafeObjectConverter` to silently return `null` and `TestConnectionAsync` to throw a 401 — blocking any user with a linked Plex account.

The Seerr API (`/api/v1/auth/me`) returns `plexId` as an integer. Aligned `User.cs` to match.

```diff
- public string? PlexId { get; set; } = null!;
+ public int? PlexId { get; set; }
```